### PR TITLE
Requirement is Go >= 1.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Installation
 
 _Requirements_
 
-* Golang >= 1.0 
+* Golang >= 1.1 
 
 _Steps_
 


### PR DESCRIPTION
I stumble upon this error on Ubuntu 13.04 and stock go package:

```
$ sudo go get github.com/andrix/shubc
# github.com/andrix/shubc/scrapinghub
/usr/lib/go/src/pkg/github.com/andrix/shubc/scrapinghub/scrapinghub.go:306: undefined:  bufio.NewScanner

$ go version
go version go1.0.2
```

Looking further, looks like the class `NewScanner` was added in Go 1.1: http://golang.org/doc/go1.1#bufio_scanner

After upgrading to Go 1.1, I was able to install and enjoy `shubc`.
